### PR TITLE
Skip <g> elements with clip-path or mask in FlattenGroups

### DIFF
--- a/src/Service/Rule/FlattenGroups.php
+++ b/src/Service/Rule/FlattenGroups.php
@@ -56,6 +56,10 @@ final readonly class FlattenGroups implements SvgOptimizerRuleInterface
         $domElementList = $domXPath->query(self::XPATH_GROUP_ELEMENTS);
 
         foreach ($domElementList as $domElement) {
+            if ($domElement->hasAttribute(SvgAttribute::ClipPath->value) || $domElement->hasAttribute(SvgAttribute::Mask->value)) {
+                continue;
+            }
+
             $this->applyGroupAttributesToChildren($domElement);
             $this->flattenGroup($domElement);
         }

--- a/tests/Unit/Service/Rule/FlattenGroupsTest.php
+++ b/tests/Unit/Service/Rule/FlattenGroupsTest.php
@@ -280,6 +280,51 @@ final class FlattenGroupsTest extends TestCase
                 XML,
         ];
 
+        yield 'Nested groups with clip-path are not flattened' => [
+            <<<'XML'
+                <svg xmlns="http://www.w3.org/2000/svg" width="750" height="600">
+                    <defs>
+                        <clipPath id="d"><path d="M0,0H100V200H0Z" fill="none"/></clipPath>
+                        <clipPath id="e"><rect x="-16" y="-28" width="782" height="657" fill="none"/></clipPath>
+                        <clipPath id="f"><rect x="-21" y="-33" width="792" height="667" fill="none"/></clipPath>
+                    </defs>
+                    <g>
+                        <g clip-path="url(#d)">
+                            <g clip-path="url(#e)">
+                                <g clip-path="url(#f)">
+                                    <rect x="0" y="0" width="750" height="600"/>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </svg>
+                XML,
+            <<<'XML'
+                <svg xmlns="http://www.w3.org/2000/svg" width="750" height="600"><defs><clipPath id="d"><path d="M0,0H100V200H0Z" fill="none"/></clipPath><clipPath id="e"><rect x="-16" y="-28" width="782" height="657" fill="none"/></clipPath><clipPath id="f"><rect x="-21" y="-33" width="792" height="667" fill="none"/></clipPath></defs><g clip-path="url(#d)"><g clip-path="url(#e)"><g clip-path="url(#f)"><rect x="0" y="0" width="750" height="600"/></g></g></g></svg>
+                XML,
+        ];
+
+        yield 'Nested groups with mask are not flattened' => [
+            <<<'XML'
+                <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+                    <defs>
+                        <mask id="m"><rect width="100" height="50" fill="white"/></mask>
+                        <mask id="n"><rect width="80" height="40" fill="white"/></mask>
+                    </defs>
+                    <g>
+                        <g mask="url(#m)">
+                            <g mask="url(#n)">
+                                <rect x="0" y="0" width="100" height="100"/>
+                            </g>
+                        </g>
+                    </g>
+                </svg>
+                XML,
+            <<<'XML'
+                <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><defs><mask id="m"><rect width="100" height="50" fill="white"/></mask><mask id="n"><rect width="80" height="40" fill="white"/></mask></defs><g mask="url(#m)"><g mask="url(#n)"><rect x="0" y="0" width="100" height="100"/></g></g></svg>
+                XML,
+        ];
+
         yield 'Group with empty attributes' => [
             <<<'XML'
                 <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">


### PR DESCRIPTION
Hi @MathiasReker,

thank you for creating and maintaining this library. 

I encountered some issues with SVGs that use multiple nested <g> elements with the `clip-path` or `mask` attributes; these were corrupted by the FlattenGroups rule. When a group was flattened, only one clipping path remained and the others were silently removed, or the wrong clipping path was applied. The visual output was therefore incorrect (missing areas, incorrect positioning). I’ve attached a test file so you can reproduce this behavior. And here’s an example of such nested groups:

```html
<g clip-path="url(#d)">  
  <g clip-path="url(#e)">
    <g clip-path="url(#f)">
      ...
    </g>
  </g>
</g>
```

FlattenGroups processed all <g> elements unconditionally. An SVG element can only carry a single clip-path or mask value, so merging a group that owns one of these attributes always destroys the remaining layers.

Groups that have a `clip-path` or `mask` attribute are now skipped entirely with this PR, matching the behaviour of SVGO's collapseGroups plugin, see https://github.com/svg/svgo/blob/6fd58725fc934ab51bc4ed84e7299dc73d72442b/plugins/collapseGroups.js#L81-L82.

Let me know what you think :)

![flattenGroups-test](https://github.com/user-attachments/assets/b589d76e-fc3f-4ec9-92dc-d3b23b5b37d1)